### PR TITLE
added ios backgrounding support to match current android functionality

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,11 @@
                 <param name="ios-package" value="BluetoothLePlugin" />
             </feature>
         </config-file>
+        <config-file target="*-Info.plist" parent="UIBackgroundModes">
+            <array>
+              <string>bluetooth-central</string>
+            </array>
+        </config-file>
         <header-file src="src/ios/BluetoothLePlugin.h" />
         <source-file src="src/ios/BluetoothLePlugin.m" />
         <framework src="CoreBluetooth.framework" />

--- a/src/ios/BluetoothLePlugin.m
+++ b/src/ios/BluetoothLePlugin.m
@@ -116,7 +116,7 @@ NSString *const logWriteDescriptorValueNotFound = @"Write descriptor value not f
         return;
     }
     
-    centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+    centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil options:@{ CBCentralManagerOptionRestoreIdentifierKey:@"bluetoothleplugin" }];
     initCallback = command.callbackId;
 }
 
@@ -1649,6 +1649,10 @@ NSString *const logWriteDescriptorValueNotFound = @"Write descriptor value not f
     }
     
     return descriptor;
+}
+
+-(void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary *)dict{
+    
 }
 
 @end


### PR DESCRIPTION
Add backgrounding support for IOS to match Androids implementation

See here for the restoration and preservation API.
https://developer.apple.com/Library/ios/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/CoreBluetoothBackgroundProcessingForIOSApps/PerformingTasksWhileYourAppIsInTheBackground.html

We need to change very few things for basic support actuality.
