### PR TITLE
GATT notifications : use setCharacteristicNotification from Android 4.3

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -1730,6 +1730,10 @@ public class BluetoothLePlugin extends CordovaPlugin {
       return false;
     }
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      bluetoothGatt.setCharacteristicNotification(characteristic, true);
+    }
+
     BluetoothGattDescriptor descriptor = characteristic.getDescriptor(clientConfigurationDescriptorUuid);
 
     if (isNotDescriptor(descriptor, device, callbackContext)) {
@@ -1821,6 +1825,10 @@ public class BluetoothLePlugin extends CordovaPlugin {
 
     if (isNotCharacteristic(characteristic, device, callbackContext)) {
       return false;
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      bluetoothGatt.setCharacteristicNotification(characteristic, false);
     }
 
     BluetoothGattDescriptor descriptor = characteristic.getDescriptor(clientConfigurationDescriptorUuid);


### PR DESCRIPTION
Hi,

This pull request solve a critical bug in gatt notification. I experienced the issue #294 on Android 5.1 (Nexus 6) and Android 6.0 (Samsung S6).

In my case, the subscribe success callback was called first with the status `subscribed` but was never called with the status `subscribedResult`. After receiving the status `subscribed`, the subscribe error callback was called with an `isDisconnected` error.

The Android documentation (https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#notification) say that we must call the `BluetoothGatt#setCharacteristicNotification()` to enable/disable characteristic notification.

This method call is missing in the `BluetoothLePlugin#subscribeAction()` and `BluetoothLePlugin#unsubscribeAction()` methods. 

Note : The `BluetoothGatt#setCharacteristicNotification()` method is available in the SDK from jelly bean.