### PR TITLE
Improve Windows platform support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -295,7 +295,7 @@ bluetoothle.startScan(startScanSuccess, startScanError, params);
 ```
 
 ##### Params #####
-* services = An array of service IDs to filter the scan or empty array / null
+* services = An array of service IDs to filter the scan or empty array / null. This parameter is not supported on Windows platform yet.
 * iOS - See [iOS Docs](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManager_Class/#//apple_ref/doc/constant_group/Peripheral_Scanning_Options)
   * allowDuplicates = True/false to allow duplicate advertisement packets, defaults to false.
 * Android - See [Android Docs](http://developer.android.com/reference/android/bluetooth/le/ScanSettings.html)
@@ -326,6 +326,7 @@ bluetoothle.startScan(startScanSuccess, startScanError, params);
   * rssi = signal strength
   * advertisement = advertisement data in encoded string of bytes, use bluetoothle.encodedStringToBytes() (Android)
   * advertisement = advertisement hash with the keys specified [here](https://developer.apple.com/library/ios/documentation/CoreBluetooth/Reference/CBCentralManagerDelegate_Protocol/#//apple_ref/doc/constant_group/Advertisement_Data_Retrieval_Keys) (iOS)
+  * advertisement = empty (Windows)
 
 ```javascript
 {
@@ -2044,10 +2045,9 @@ The BluetoothLE plugin uses an adapter to interact with each device's Bluetooth 
 
 document.addEventListener('deviceready', function () {
 
-    new Promise(function (resolve, reject) {
+    new Promise(function (resolve) {
 
-        bluetoothle.initialize(resolve, reject,
-            { request: true, statusReceiver: false });
+        bluetoothle.initialize(resolve, { request: true, statusReceiver: false });
 
     }).then(initializeSuccess, handleError);
 
@@ -2296,8 +2296,7 @@ function stopScan() {
 
     new Promise(function (resolve, reject) {
 
-        bluetoothle.storpScan(resolve, reject,
-            { address: result.address });
+        bluetoothle.stopScan(resolve, reject);
 
     }).then(stopScanSuccess, handleError);
 }

--- a/src/windows/BluetoothLePlugin.js
+++ b/src/windows/BluetoothLePlugin.js
@@ -275,6 +275,15 @@ module.exports = {
         status: "connected"
       };
 
+      // Attach listener to device to report disconnected event
+      bleDevice.addEventListener('connectionstatuschanged', function connectionStatusListener(e) {
+        if (e.target.connectionStatus === Windows.Devices.Bluetooth.BluetoothConnectionStatus.disconnected) {
+          result.status = "disconnected";
+          successCallback(result);
+          bleDevice.removeEventListener('connectionstatuschanged', connectionStatusListener);
+        }
+      })
+
       // Need to use keepCallback to be able to report "disconnect" event
       // https://github.com/randdusing/cordova-plugin-bluetoothle#connect
       successCallback(result, { keepCallback: true });

--- a/src/windows/BluetoothLePlugin.js
+++ b/src/windows/BluetoothLePlugin.js
@@ -115,7 +115,7 @@ module.exports = {
       for (var i = 0; i < params[0].services.length; i++) {
         var uuid = params[0].services[i];
         if (uuid.length == 4) {
-          uuid = "0000" + uuid + "-0000-1000-8000-00805F9B34FB";
+            uuid = "0000" + uuid + "-0000-1000-8000-00805F9B34FB";
         }
         selector += (i == 0) ? " AND ( " : " OR ";
         selector += "System.DeviceInterface.Bluetooth.ServiceGuid:=\"{" + uuid + "}\"";
@@ -325,15 +325,15 @@ module.exports = {
           var deviceName;
           var serviceIds = [];
           for (var i = 0; i < services.length; i++) {
-            var UuidRe = /\{([0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12})\}_/;
-            var serviceId = UuidRe.exec(services[i].id)[1];
-            var re = /0000([0-9a-f]{4})\-0000\-1000\-8000\-00805f9b34fb/;
-            var shortUuidMatch = re.exec(serviceId);
-            if (shortUuidMatch != null) {
-              serviceId = shortUuidMatch[1];
-            }
-            serviceIds.push(serviceId);
-            deviceName = services[i].name;
+              var UuidRe = /\{([0-9a-f]{8}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{4}\-[0-9a-f]{12})\}_/;
+              var serviceId = UuidRe.exec(services[i].id)[1];
+              var re = /0000([0-9a-f]{4})\-0000\-1000\-8000\-00805f9b34fb/;
+              var shortUuidMatch = re.exec(serviceId);
+              if (shortUuidMatch != null) {
+                serviceId = shortUuidMatch[1];
+              }
+              serviceIds.push(serviceId);
+              deviceName = services[i].name;
           }
           successCallback({ status: "services", services: serviceIds, name: deviceName, address: deviceId });
         } else {
@@ -540,9 +540,9 @@ module.exports = {
       var value = params[0].value;
       var writeOption;
       if (params[0].type !== undefined && params[0].type == "noResponse") {
-        writeOption = gatt.GattWriteOption.writeWithoutResponse;
+          writeOption = gatt.GattWriteOption.writeWithoutResponse;
       } else {
-        writeOption = gatt.GattWriteOption.writeWithResponse;
+          writeOption = gatt.GattWriteOption.writeWithResponse;
       }
 
       getCharacteristic(deviceId, serviceId, characteristicId).then(function (characteristic, deviceName) {
@@ -643,22 +643,22 @@ function getService(deviceId, serviceId) {
       }
     }
     if (serviceId.length == 4) {
-      serviceId = "0000" + serviceId + "-0000-1000-8000-00805F9B34FB";
+        serviceId = "0000" + serviceId + "-0000-1000-8000-00805F9B34FB";
     }
     var selector = "System.Devices.ContainerId:={" + deviceId + "} AND System.DeviceInterface.Bluetooth.ServiceGuid:=\"{" + serviceId + "}\" AND System.Devices.InterfaceClassGuid:=\"{6E3BB679-4372-40C8-9EAA-4509DF260CD8}\" AND System.Devices.InterfaceEnabled:=System.StructuredQueryType.Boolean#True";
     deviceInfo.findAllAsync(selector, null).then(function (services) {
       if (services.length > 0) {
         gatt.GattDeviceService.fromIdAsync(services[0].id)
-          .then(function (deviceService) {
-            if (deviceService) {
-              cachedServices.push({ deviceId: deviceId, serviceId: serviceId, deviceService: deviceService });
-              successCallback(deviceService);
-            } else {
-              errorCallback("Error retrieving deviceService, check the app's permissions for this service (plugin.xml).");
-            }
-          }, function (error) {
-            errorCallback(error);
-          });
+         .then(function (deviceService) {
+           if (deviceService) {
+             cachedServices.push({ deviceId: deviceId, serviceId: serviceId, deviceService: deviceService });
+             successCallback(deviceService);
+           } else {
+             errorCallback("Error retrieving deviceService, check the app's permissions for this service (plugin.xml).");
+           }
+         }, function (error) {
+           errorCallback(error);
+         });
       } else {
         errorCallback("Device or service not found.");
       }
@@ -764,16 +764,16 @@ function getCharacteristicsInfo(serviceId, characteristicId) {
 
 function getServiceInfos() {
   return [
-    {
-      uuid: 0x1811,
-      characteristics: [
-        { uuid: 0x2A47, descriptors: [] },
-        { uuid: 0x2A46, descriptors: [0x2902, ] },
-        { uuid: 0x2A48, descriptors: [] },
-        { uuid: 0x2A45, descriptors: [0x2902, ] },
-        { uuid: 0x2A44, descriptors: [] },
-      ]
-    },
+   {
+     uuid: 0x1811,
+     characteristics: [
+       { uuid: 0x2A47, descriptors: [] },
+       { uuid: 0x2A46, descriptors: [0x2902, ] },
+       { uuid: 0x2A48, descriptors: [] },
+       { uuid: 0x2A45, descriptors: [0x2902, ] },
+       { uuid: 0x2A44, descriptors: [] },
+     ]
+   },
   {
     uuid: 0x180F,
     characteristics: [


### PR DESCRIPTION
This PR adds some improvements, related to discovery of and connection to Bluetooth devices on windows.
Specifically the following changes were made: 

1. Reworked `initialize` method to look for available Bluetooth controllers (when corresponding API is 
available) to determine initialization status rather than enumerate surrounding Bluetooth devices. Also 
see #284 
2. Added scanning functionality. Now it's possible to invoke `startscan` / `stopscan` methods to discover 
all Bluetooth devices around instead of using `retrieveconnected` . 
3. Added `connect` method which, similarly to Android, is required to be called before device's services 
can be read. Internally this method tries to pair with device, which is required by Windows.

/cc: @TimBarham 