### PR TITLE
Android discovery refresh

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -622,7 +622,7 @@ bluetoothle.close(closeSuccess, closeError, params);
 
 
 ### discover ###
-Discover all the devices services, characteristics and descriptors. Doesn't need to be called again after disconnecting and then reconnecting. If using iOS, you shouldn't use discover and services/characteristics/descriptors on the same device. There seems to be an issue with calling discover on iOS8 devices, so use with caution.
+Discover all the devices services, characteristics and descriptors. Doesn't need to be called again after disconnecting and then reconnecting. If using iOS, you shouldn't use discover and services/characteristics/descriptors on the same device. There seems to be an issue with calling discover on iOS8 devices, so use with caution.  On some Android versions, the discovered services may be cached for a device.  Subsequent discover events will make use of this cache.  If your device's services change, set the clearCache parameter to force Android to re-discover services.
 
 ```javascript
 bluetoothle.discover(discoverSuccess, discoverError, params);
@@ -630,10 +630,12 @@ bluetoothle.discover(discoverSuccess, discoverError, params);
 
 ##### Params #####
 * address = The address/identifier provided by the scan's return object
+* clearCache = true / false (default) Force the device to re-discover services, instead of relying on cache from previous discovery (Android only)
 
 ```javascript
 {
-  "address": "00:22:D0:3B:32:10"
+  "address": "00:22:D0:3B:32:10",
+  "clearCache": true
 }
 ```
 

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -85,6 +85,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
   private final int STATE_UNDISCOVERED = 0;
   private final int STATE_DISCOVERING = 1;
   private final int STATE_DISCOVERED = 2;
+  private final String discoverClearCache = "clearCache";
 
   //Quick Writes
   private LinkedList<byte[]> queueQuick = new LinkedList<byte[]>();
@@ -1631,7 +1632,35 @@ public class BluetoothLePlugin extends CordovaPlugin {
     connection.put(keyDiscoveredState, STATE_DISCOVERING);
     connection.put(operationDiscover, callbackContext);
 
+    boolean clearCache = false;
+    if (obj != null) {
+      clearCache = getClearCache(obj);
+    }
+
+    if (clearCache) {
+      refreshDeviceCache(bluetoothGatt);
+    }
+
     bluetoothGatt.discoverServices();
+  }
+
+  private boolean getClearCache(JSONObject obj) {
+    return obj.optBoolean(discoverClearCache, false);
+  }
+
+  private boolean refreshDeviceCache(BluetoothGatt gatt) {
+    try {
+      BluetoothGatt localBluetoothGatt = gatt;
+      java.lang.reflect.Method localMethod = localBluetoothGatt.getClass().getMethod("refresh", new Class[0]);
+      if (localMethod != null) {
+        boolean bool = ((Boolean) localMethod.invoke(localBluetoothGatt, new Object[0])).booleanValue();
+        return bool;
+      }
+    } 
+    catch (Exception localException) {
+      Log.e("BLE", "An exception occured while refreshing device cache");
+    }
+    return false;
   }
 
   private boolean readAction(Operation operation) {


### PR DESCRIPTION
Android appears to cache discovered services (and subsequently characteristics and descriptors) at the system level.  I found even removing and re-installing an app will not clear the cache.  As such, I've added a boolean flag to the discover service, which when true calls an Android function to force re-discovery of the services.

A potential issue - some deeper googling indicates that some vendors remove this method from the bluetooth library.  Perhaps they implement their own equivalent?  In this case, it seems the function may not work on all android devices.