### PR TITLE
Add `cordovaDependencies` section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,17 @@
     "cordova-ios",
     "cordova-windows"
   ],
-  "engines": [
-    {
-      "name": "cordova-plugman",
-      "version": ">=5.0.0"
-    },
-    {
-      "name": "cordova-android",
-      "version": ">=5.0.0"
+  "engines": {
+    "cordovaDependencies": {
+      "4.2.0": {
+        "cordova": ">=5.0.0",
+        "cordova-android": ">=5.0.0"
+      },
+      "5.0.0": {
+        "cordova": ">=100"
+      }
     }
-  ],
+  },
   "author": "Rand Dusing",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This PR updates 'engines' in 'package.json' to comply w/ manifest format (`engines` value should be an object, not an array) and [new plugin fetching model](https://github.com/cordova/cordova-discuss/blob/master/proposals/plugin-version-fetching.md).

Also there is no 5.0.0 version of 'cordova-plugman' so it has been updated to just 'cordova'.

This also adds a 'protective' entry for next major plugin version to protect end-users from fetching edge versions of the plugin by incompatible version of cordova. _This requires explicitly updating of package.json on every major plugin release to make it 'installable' by cordova._

See corresponding [discussion on mailing list](http://apache.markmail.org/thread/p73loqtvbzvfzsv5) for more details and reasons behind this.


