### PR TITLE
Add getAdapterInfo for Android

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,7 @@ Neither Android nor iOS support Bluetooth on emulators, so you'll need to test o
 * [bluetoothle.initialize] (#initialize)
 * [bluetoothle.enable] (#enable) (Android)
 * [bluetoothle.disable] (#disable) (Android)
+* [bluetoothle.getAdapterInfo] (#getAdapterInfo) (Android)
 * [bluetoothle.startScan] (#startscan)
 * [bluetoothle.stopScan] (#stopscan)
 * [bluetoothle.retrieveConnected] (#retrieveconnected)
@@ -290,6 +291,27 @@ bluetoothle.disable(disableSuccess, disableError);
 ##### Success #####
 The successCallback isn't actually used. Listen to initialize callbacks for change in Bluetooth state. A successful disable will return an error => enable via initialize error callback.
 
+
+### getAdapterInfo ###
+Retrieve useful information such as the address, name, and various states (initialized, enabled, scanning, discoverable).
+This can be very useful when the general state of the adapter has been lost, and we would otherwise need to go through a series of callbacks to get the correct state (first initialized, then enabled, then isScanning, and so forth). 
+The result of this method allows us to take business logic decisions while avoiding a large part of the callback hell.
+
+Currently the discoverable state does not have any relevance because there is no "setDiscoverable" functionality in place.
+That may change in the future.
+
+```javascript
+bluetoothle.getAdapterInfo(successCallback);
+```
+
+##### Success #####
+The successCallback contains the following properties:
+ * name = the adapters's display name
+ * address = the adapter's address
+ * isInitialized = boolean value, true if the adapter was initialized, otherwise false
+ * isEnabled = boolean value, true if the adapter was enabled, otherwise false
+ * isScanning = boolean value, true if the adapter is currently scanning, otherwise false
+ * isDiscoverable = boolean value, true if the adapter is in discoverable mode, otherwise false (currently largely false)
 
 
 ### startScan ###

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -123,6 +123,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
   private final String keyIsBonded = "isBonded";
   private final String keyIsConnected = "isConnected";
   private final String keyIsDiscovered = "isDiscovered";
+  private final String keyIsDiscoverable = "isDiscoverable";
   private final String keyPeripheral = "peripheral";
   private final String keyState = "state";
   private final String keyDiscoveredState = "discoveredState";
@@ -309,6 +310,8 @@ public class BluetoothLePlugin extends CordovaPlugin {
       initializeAction(args, callbackContext);
     } else if ("enable".equals(action)) {
       enableAction(callbackContext);
+    } else if ("getAdapterInfo".equals(action)) {
+      getAdapterInfoAction(callbackContext);
     } else if ("disable".equals(action)) {
       disableAction(callbackContext);
     } else if ("startScan".equals(action)) {
@@ -1006,6 +1009,47 @@ public class BluetoothLePlugin extends CordovaPlugin {
       pluginResult.setKeepCallback(true);
       initCallbackContext.sendPluginResult(pluginResult);
     }
+  }
+
+  
+  /**
+  * Retrieves a minimal set of adapter details 
+  * (address, name, initialized state, enabled state, scanning state, discoverable state)
+  */
+  private void getAdapterInfoAction(CallbackContext callbackContext) {    
+    JSONObject returnObj = new JSONObject();    
+
+    // Not yet initialized
+    if (bluetoothAdapter == null) {      
+      Activity activity = cordova.getActivity();
+      BluetoothManager bluetoothManager = (BluetoothManager) activity.getSystemService(Context.BLUETOOTH_SERVICE);
+      BluetoothAdapter bluetoothAdapterTmp = bluetoothManager.getAdapter();
+
+      // Since the adapter is not officially initialized, retrieve only the address and the name from the temp ad-hoc adapter
+      addProperty(returnObj, keyAddress, bluetoothAdapterTmp.getAddress());
+      addProperty(returnObj, keyName, bluetoothAdapterTmp.getName());
+      addProperty(returnObj, keyIsInitialized, false);
+      addProperty(returnObj, keyIsEnabled, false);
+      addProperty(returnObj, keyIsScanning, false);
+      addProperty(returnObj, keyIsDiscoverable, false);
+      PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, returnObj);
+      pluginResult.setKeepCallback(true);
+      callbackContext.sendPluginResult(pluginResult);
+      return;      
+    } else {
+      // Already initialized, so use the bluetoothAdapter class property to get all the info
+      addProperty(returnObj, keyAddress, bluetoothAdapter.getAddress());
+      addProperty(returnObj, keyName, bluetoothAdapter.getName());
+      addProperty(returnObj, keyIsInitialized, true);
+      addProperty(returnObj, keyIsEnabled, bluetoothAdapter.isEnabled());
+      addProperty(returnObj, keyIsScanning, bluetoothAdapter.isDiscovering());
+      addProperty(returnObj, keyIsDiscoverable, bluetoothAdapter.getScanMode() == BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE);
+      PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, returnObj);
+      pluginResult.setKeepCallback(true);
+      callbackContext.sendPluginResult(pluginResult);      
+      return;
+    }
+    
   }
 
   private void enableAction(CallbackContext callbackContext) {

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -1042,7 +1042,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
       addProperty(returnObj, keyName, bluetoothAdapter.getName());
       addProperty(returnObj, keyIsInitialized, true);
       addProperty(returnObj, keyIsEnabled, bluetoothAdapter.isEnabled());
-      addProperty(returnObj, keyIsScanning, bluetoothAdapter.isDiscovering());
+      addProperty(returnObj, keyIsScanning, (scanCallbackContext != null));
       addProperty(returnObj, keyIsDiscoverable, bluetoothAdapter.getScanMode() == BluetoothAdapter.SCAN_MODE_CONNECTABLE_DISCOVERABLE);
       PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, returnObj);
       pluginResult.setKeepCallback(true);

--- a/www/bluetoothle.js
+++ b/www/bluetoothle.js
@@ -9,6 +9,9 @@ var bluetoothle = {
   disable: function(successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, bluetoothleName, "disable", []);
   },
+  getAdapterInfo: function(successCallback) {
+    cordova.exec(successCallback, successCallback, bluetoothleName, "getAdapterInfo", []);
+  },  
   startScan: function(successCallback, errorCallback, params) {
     cordova.exec(successCallback, errorCallback, bluetoothleName, "startScan", [params]);
   },


### PR DESCRIPTION
The getAdapterInfo method retrieves the address and the BLE name on the Android device proper.
If bluetoothAdapter is null, a temporary bluetoothAdapterTmp would be used to extract the name and the address, for zero impact to the legacy flow.

Alongside the name and address, various states (initialized, enabled, scanning, discoverable) are also returned. This can be very useful when the general state of the adapter has been lost, and we would otherwise need to go through a series of callbacks to get the correct state (first initialized, then enabled, then isScanning, and so forth). The result of this method allows us to take business logic decisions while avoiding a large part of the callback hell.