### PR TITLE
Fix to allow setting of empty values

### DIFF
--- a/src/ios/BluetoothLePlugin.m
+++ b/src/ios/BluetoothLePlugin.m
@@ -3336,10 +3336,6 @@ NSString *const operationWrite = @"write";
 
   NSData *data = [[NSData alloc] initWithBase64EncodedString:string options:0];
 
-  if (data == nil || data.length == 0) {
-    return nil;
-  }
-
   return data;
 }
 


### PR DESCRIPTION
Currently getValue does not allow the setting of 0-length values, but setting a characteristic's value to empty is a perfectly valid thing to want to do.