### PR TITLE
Make scanning restartable on Windows

### DIFF
--- a/src/windows/BluetoothLePlugin.js
+++ b/src/windows/BluetoothLePlugin.js
@@ -157,6 +157,7 @@ module.exports = {
 
     if (WATCHER.status !== DeviceWatcherStatus.started &&
       WATCHER.status !== DeviceWatcherStatus.created &&
+      WATCHER.status !== DeviceWatcherStatus.stopped &&
       WATCHER.status !== DeviceWatcherStatus.aborted) {
 
       errorCallback({ error: "startScan", message: 'Scan already in progress' });


### PR DESCRIPTION
On Windows 10, once scanning stopped, it cannot restart again.

```js
bluetoothle.startScan(/*...*/); // Success

//
// ...
//

bluetoothle.stopScan(/*...*/); // Success

//
// ...
//

bluetoothle.startScan(/*...*/); // Error

```

After scanning stopped, WATCHER.status will be DeviceWatcherStatus.stopped.
On this status, errorCallback is always fired on startScan execution.

```js
    if (WATCHER.status !== DeviceWatcherStatus.started &&
      WATCHER.status !== DeviceWatcherStatus.created &&
      WATCHER.status !== DeviceWatcherStatus.aborted) {

      errorCallback({ error: "startScan", message: 'Scan already in progress' });
      return;
    }
```

About application execution environment:
* Edition: Windows 10 Pro
* Version: 1703
* OS Build: 15063.413
