### PR TITLE
Fixed namespace typo

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace BluetootlePlugin {
+declare namespace BluetoothlePlugin {
     interface Bluetoothle {
         /**
          * Initialize Bluetooth on the device


### PR DESCRIPTION
The namespace is named incorrectly. It´s called 'Bluetootle' without the H.