### PR TITLE
#455 on BT state OFF stopping scan for Android version 6.0.0 or above

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -2779,6 +2779,11 @@ public class BluetoothLePlugin extends CordovaPlugin {
             addProperty(returnObj, keyMessage, logNotEnabled);
 
             connections = new HashMap<Object, HashMap<Object, Object>>();
+            if (scanCallbackContext != null) {
+              if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                bluetoothAdapter.getBluetoothLeScanner().stopScan(scanCallback);
+              }
+            }
             scanCallbackContext = null;
 
             pluginResult = new PluginResult(PluginResult.Status.OK, returnObj);


### PR DESCRIPTION
I tried using the same code as in stopScanAction. I don't know why but the app crashes for LOLLIPOP 5.1.1.
So I changed the check for marshmello (M)


