### PR TITLE
Replaced peripheralDidUpdateRSSI with didReadRSSI method.

### DIFF
--- a/src/ios/BluetoothLePlugin.m
+++ b/src/ios/BluetoothLePlugin.m
@@ -2071,10 +2071,6 @@ NSString *const operationWrite = @"write";
   [self.commandDelegate sendPluginResult:pluginResult callbackId:initCallback];
 }
 
-- (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary *)dict {
-  //Needed to support background mode
-}
-
 - (void)centralManager:(CBCentralManager *)central didDiscoverPeripheral:(CBPeripheral *)peripheral advertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber *)RSSI {
   //If no scan callback, nothing can be returned
   if (scanCallback == nil) {

--- a/src/ios/BluetoothLePlugin.m
+++ b/src/ios/BluetoothLePlugin.m
@@ -2071,6 +2071,10 @@ NSString *const operationWrite = @"write";
   [self.commandDelegate sendPluginResult:pluginResult callbackId:initCallback];
 }
 
+- (void)centralManager:(CBCentralManager *)central willRestoreState:(NSDictionary *)dict {
+  //Needed to support background mode
+}
+
 - (void)centralManager:(CBCentralManager *)central didDiscoverPeripheral:(CBPeripheral *)peripheral advertisementData:(NSDictionary *)advertisementData RSSI:(NSNumber *)RSSI {
   //If no scan callback, nothing can be returned
   if (scanCallback == nil) {


### PR DESCRIPTION
Also removed unneeded willRestoreState method.

With the "peripheralDidUpdateRSSI" on iOS 11, we where experiencing crashes (possibly due to incorrect error handling..) when our app was running in the background while polling the RSSI.
Since a while "peripheralDidUpdateRSSI" was already deprecated, the new method is introduced in iOS8, and this change effectively makes the code broken for older versions.