### PR TITLE
Rewrite Windows 10 support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Cordova Bluetooth LE Plugin
-This plugin allows you to interact with Bluetooth LE devices on Android, iOS, and partially on Windows.
+This plugin allows you to interact with Bluetooth LE devices on Android, iOS, and Windows.
 
 
 ## Requirements ##
@@ -8,6 +8,7 @@ This plugin allows you to interact with Bluetooth LE devices on Android, iOS, an
 * Android 4.3 or higher, Android Cordova library 5.0.0 or higher, target Android API 23 or higher
 * iOS 7 or higher
 * Windows Phone 8.1 (Tested on Nokia Lumia 630)
+* Windows 10 UWP
 * Device hardware must be certified for Bluetooth LE. i.e. Nexus 7 (2012) doesn't support Bluetooth LE even after upgrading to 4.3 (or higher) without a modification
 * List of devices: http://www.bluetooth.com/Pages/Bluetooth-Smart-Devices-List.aspx
 
@@ -31,7 +32,6 @@ This plugin allows you to interact with Bluetooth LE devices on Android, iOS, an
 
 ## To Do ##
 
-* Expand Windows support
 * Improved notifications on peripheral/server role between Android and iOS
 * Code refactoring. It's getting pretty messy.
 
@@ -101,6 +101,7 @@ One option is to set Manufacturer Specific Data in the advertisement packet if t
 Another option is to connect to the device and use the "Device Information" (0x180A) service, but connecting to each device is much more energy intensive than scanning for advertisement data.
 See the following StackOverflow posts for more info: [here](https://stackoverflow.com/questions/18973098/get-mac-address-of-bluetooth-low-energy-peripheral) and [here](https://stackoverflow.com/questions/22833198/get-advertisement-data-for-ble-in-ios)
 
+Advertisement data is not supported on Windows 10 UWP. 
 
 ## Emulator ##
 Neither Android nor iOS support Bluetooth on emulators, so you'll need to test on a real device.
@@ -330,6 +331,8 @@ bluetoothle.startScan(startScanSuccess, startScanError, params);
   * matchMode - Defaults to Aggressive. Available from API23.
   * matchNum - Defaults to One Advertisement. Available from API23.
   * callbackType - Defaults to All Matches. Available from API21 / API 23. *Note: Careful using this one. When using CALLBACK_TYPE_FIRST_MATCH on a Nexus 7 on API 21, I received a Feature Unsupported error when starting the scan.
+* Windows 10 UWP
+  * isConnectable - Windows 10 will, by default, show all devices ever seen by the system, even if the device is off. If you want to only devices that are on and connectable, set this to true.
 
 ```javascript
 {

--- a/src/windows/BluetoothLePlugin.js
+++ b/src/windows/BluetoothLePlugin.js
@@ -151,7 +151,6 @@ module.exports = {
       if (params && params[0] && params[0].isConnectable) {
         selector += ' AND System.Devices.Aep.Bluetooth.Le.IsConnectable:=System.StructuredQueryType.Boolean#True';
       }
-      console.info('selector used is', selector);
       WATCHER = WindowsDeviceInfo.createWatcher(selector, PROPERTY_COLLECTION);
     }
 
@@ -227,46 +226,16 @@ module.exports = {
     }
 
     getDeviceByAddress(address)
-    // .then(function (bleDevice) {
-    //   var DevicePairingProtectionLevel = Windows.Devices.Enumeration.DevicePairingProtectionLevel;
-    //   var DevicePairingResultStatus = Windows.Devices.Enumeration.DevicePairingResultStatus;
-    //
-    //   if (!bleDevice || !bleDevice.deviceInformation || !bleDevice.deviceInformation.pairing) {
-    //     throw {error: "connect", message: "The device is not found"};
-    //   }
-    //
-    //   if (bleDevice.deviceInformation.pairing.isPaired) {
-    //     return bleDevice;
-    //   }
-    //
-    //   if (!bleDevice.deviceInformation.pairing.canPair) {
-    //     throw { error: "connect", message: "The device does not support pairing" };
-    //   }
-    //
-    //   // TODO: investigate if it is possible to pair without user prompt
-    //   return bleDevice.deviceInformation.pairing.pairAsync(DevicePairingProtectionLevel.none)
-    //   .then(function (res) {
-    //     if (res.status === DevicePairingResultStatus.paired ||
-    //         res.status === DevicePairingResultStatus.alreadyPaired)
-    //       return bleDevice;
-    //
-    //     // TODO: provide error code based on DevicePairingResultStatus.alreadyPaired enum
-    //     throw { error: "connect", message: "The device rejected the connection" };
-    //   });
-    // })
     .then(function(bleDevice){
       if (bleDevice.connectionStatus === BluetoothConnectionStatus.connected) {
-        console.log('device is connected');
         return bleDevice;
       }
-      console.log('device is not connected');
       //if we're not already connected, getting the services will cause a connection to happen
       return bleDevice.getGattServicesAsync(WindowsBluetooth.BluetoothCacheMode.uncached).then(function(){
         return bleDevice;
       });
     })
     .done(function (bleDevice) {
-      console.log('result of connect', bleDevice, bleDevice.connectionStatus === BluetoothConnectionStatus.connected);
       var result = {
         name: bleDevice.deviceInformation.name,
         address: address,
@@ -275,15 +244,12 @@ module.exports = {
 
       // Attach listener to device to report disconnected event
       bleDevice.addEventListener('connectionstatuschanged', function connectionStatusListener(e) {
-        console.log('connection changed event', e, e.target.connectionStatus === BluetoothConnectionStatus.disconnected);
         if (e.target.connectionStatus === BluetoothConnectionStatus.disconnected) {
           result.status = "disconnected";
-          console.log('calling connect callback with', result);
           successCallback(result);
           bleDevice.removeEventListener('connectionstatuschanged', connectionStatusListener);
         }
       });
-      console.log('calling connect callback with', result);
       // Need to use keepCallback to be able to report "disconnect" event
       // https://github.com/randdusing/cordova-plugin-bluetoothle#connect
       successCallback(result, { keepCallback: true });
@@ -502,8 +468,6 @@ module.exports = {
       return;
     }
 
-    console.log('params to subscribe', params);
-
     if (params && params.length > 0 && params[0].address && params[0].service && params[0].characteristic) {
       var deviceId = params[0].address;
       var serviceId = params[0].service;
@@ -539,7 +503,6 @@ module.exports = {
         errorCallback({ error: "subscribe", message: error });
       });
     } else {
-      console.log('invalid params', params && params[0]);
       errorCallback({ error: "subscribe", message: "Invalid parameters." });
     }
   },
@@ -787,7 +750,6 @@ androidActions.forEach(function(key){
 
   module.exports[key] = function(successCallback, errorCallback, params) {
     var error = 'Function "' + key + '" is not implemented';
-    console.error(error);
     errorCallback({error: key, message: error});
   };
 });


### PR DESCRIPTION
This PR is to bring Windows 10 UWP support up to about the same level as Android and iPhone.

I did what I could to make the experience the same between the platforms.

We're using this plugin in an app that's targeting Android, iOS and Windows. With this PR, the app works as expected across the three.

The major missing functionality is advertisement data. I'm still working on that, but right now it appears as though the end-user has to jump through a lot of hoops to get it working so it may not be viable.

This closes #487, closes #491, closes #501, closes #508, and closes #509 