### PR TITLE
add ble write response error code to returned object

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -4092,6 +4092,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
 
           addProperty(returnObj, keyError, errorWrite);
           addProperty(returnObj, keyMessage, logWriteFailReturn);
+          addProperty(returnObj, keyStatus, status);
           callbackContext.error(returnObj);
         }
 
@@ -4119,6 +4120,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
         //Else it failed
         addProperty(returnObj, keyError, errorWrite);
         addProperty(returnObj, keyMessage, logWriteFailReturn);
+        addProperty(returnObj, keyStatus, status);
         callbackContext.error(returnObj);
       }
     }


### PR DESCRIPTION
This reveals the write response error code that is returned by the GATT server