### PR TITLE
Added isConnectable to ScanParams interface

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -614,7 +614,9 @@ declare namespace BluetoothlePlugin {
         /** Defaults to One Advertisement. Available from API23 (Android) */
         matchNum?: BluetoothMatchNum,
         /** Defaults to All Matches. Available from API21 / API 23. (Android) */
-        callbackType?: BluetoothCallbackType
+        callbackType?: BluetoothCallbackType,
+        /** True/false to show only connectable devices, rather than all devices ever seen, defaults to false (Windows)*/
+        isConnectable?: boolean
     }
 
     interface NotifyParams {


### PR DESCRIPTION
Docs mention isConnectable param as an option for startScan(), but ScanParams does not include it.

Windows 10 UWP
isConnectable - Windows 10 will, by default, show all devices ever seen by the system, even if the device is off. If you want to only devices that are on and connectable, set this to true.