### PR TITLE
Modify connect failure

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,6 +35,18 @@
     <header-file src="src/ios/BluetoothLePlugin.h" />
     <source-file src="src/ios/BluetoothLePlugin.m" />
     <framework src="CoreBluetooth.framework" />
+    <edit-config file="*-Info.plist" mode="merge" target="NSLocationAlwaysUsageDescription">
+      <string>Need to location permission for find the alcohol checker Do you allow this app to get location permissions?</string>
+    </edit-config>
+    <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">
+      <string>Need to location permission for find the alcohol checker Do you allow this app to get location permissions?</string>
+    </edit-config>
+    <edit-config file="*-Info.plist" mode="merge" target="NSBluetoothAlwaysUsageDescription">
+      <string>Need to bluetooth for connect alcohol checker Do you allow this app to open bluetooth?</string>
+    </edit-config>
+    <edit-config file="*-Info.plist" mode="merge" target="NSBluetoothPeripheralUsageDescription">
+      <string>Need to bluetooth for connect alcohol checker Do you allow this app to open bluetooth?</string>
+    </edit-config>
   </platform>
   <platform name="osx">
     <config-file target="config.xml" parent="/*">

--- a/plugin.xml
+++ b/plugin.xml
@@ -35,18 +35,6 @@
     <header-file src="src/ios/BluetoothLePlugin.h" />
     <source-file src="src/ios/BluetoothLePlugin.m" />
     <framework src="CoreBluetooth.framework" />
-    <edit-config file="*-Info.plist" mode="merge" target="NSLocationAlwaysUsageDescription">
-      <string>Need to location permission for find the alcohol checker Do you allow this app to get location permissions?</string>
-    </edit-config>
-    <edit-config file="*-Info.plist" mode="merge" target="NSLocationWhenInUseUsageDescription">
-      <string>Need to location permission for find the alcohol checker Do you allow this app to get location permissions?</string>
-    </edit-config>
-    <edit-config file="*-Info.plist" mode="merge" target="NSBluetoothAlwaysUsageDescription">
-      <string>Need to bluetooth for connect alcohol checker Do you allow this app to open bluetooth?</string>
-    </edit-config>
-    <edit-config file="*-Info.plist" mode="merge" target="NSBluetoothPeripheralUsageDescription">
-      <string>Need to bluetooth for connect alcohol checker Do you allow this app to open bluetooth?</string>
-    </edit-config>
   </platform>
   <platform name="osx">
     <config-file target="config.xml" parent="/*">

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -1478,11 +1478,11 @@ public class BluetoothLePlugin extends CordovaPlugin {
       autoConnect = obj.optBoolean("autoConnect", false);
     }
 
+    connections.put(device.getAddress(), connection);
+
     BluetoothGatt bluetoothGatt = device.connectGatt(cordova.getActivity().getApplicationContext(), autoConnect, bluetoothGattCallback);
 
     connection.put(keyPeripheral, bluetoothGatt);
-
-    connections.put(device.getAddress(), connection);
   }
 
   private void reconnectAction(JSONArray args, CallbackContext callbackContext) {


### PR DESCRIPTION
- Bug phenomenon
Sometimes the callback method is not called when the connection is successful.
(The frequency of connection failure on android5.1 is 50%)

- Bug reason
Get the connection object in the state change method of bluetoothGattCallback,
But at this time, the connect object has not been added to the connections list.
Caused in this case, the successful callback will not be called.

- Bug fix
The process of appending the connect object to the list is placed before the connect process.