### PR TITLE
added notificationSent to status of device

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -577,7 +577,7 @@ declare namespace BluetoothlePlugin {
         | "rssi" | "mtu" | "connectionPriorityRequested" |"enabled" | "disabled"
         | "readRequested" | "writeRequested" | "mtuChanged" | "notifyReady" | "notifySent"
         | "serviceAdded" | "serviceRemoved" | "allServicesRemoved" | "advertisingStarted"
-        | "advertisingStopped" | "responded" | "notified";
+        | "advertisingStopped" | "responded" | "notified" | "notificationSent";
 
     /** Avaialable connection priorities */
     type ConnectionPriority = "low" | "balanced" | "high";
@@ -814,7 +814,7 @@ declare namespace BluetoothlePlugin {
             writeEncryptionRequired?: boolean
         }
     }
-    
+
     interface Descriptor {
         uuid: string;
     }


### PR DESCRIPTION
When I use notify, then I receive a Bluetooth message with status: `"notificationSent"`.

I had to change type status locally to be able to do things when a notification is sent. Maybe it will be useful to other users.