### PR TITLE
FIX enabling BLE on Android

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -1056,6 +1056,10 @@ public class BluetoothLePlugin extends CordovaPlugin {
       return;
     }
 
+    //Get Bluetooth adapter via Bluetooth Manager before enable it
+    Activity activity = cordova.getActivity();
+    BluetoothManager bluetoothManager = (BluetoothManager) activity.getSystemService(Context.BLUETOOTH_SERVICE);
+    bluetoothAdapter = bluetoothManager.getAdapter();
     boolean result = bluetoothAdapter.enable();
 
     if (!result) {


### PR DESCRIPTION
When calling enable() in android nothing happens. It seems that de Bluetooth BLE adapter from the BLE manager was missing in that method. I've just inserted:
`    
Activity activity = cordova.getActivity();
BluetoothManager bluetoothManager = (BluetoothManager) activity.getSystemService(Context.BLUETOOTH_SERVICE);
bluetoothAdapter = bluetoothManager.getAdapter();`
 before: 
`boolean result = bluetoothAdapter.enable();`