### PR TITLE
Fixed not executing undefined check on Windows

### DIFF
--- a/src/windows/BluetoothLePlugin.js
+++ b/src/windows/BluetoothLePlugin.js
@@ -477,7 +477,7 @@ module.exports = {
       getCharacteristic(deviceId, serviceId, characteristicId).then(function (characteristic, deviceName) {
         var convertedCharacteristic = convertCharacteristic(characteristic);
         var descriptorValue;
-        if (isNotification === null) {
+        if (isNotification == null) {
           isNotification = convertedCharacteristic.properties.notify === 'true';
         }
 


### PR DESCRIPTION
Hello, 

I found that `subscribe` function is not work on Windows.   
A characteristic to `subscribe` function has *indicate* property.    

But, `subscribe` function sets *notify* to the characteristic.  
`if (isNotification == null) `'s result is seem to always false.

Thanks

##### `BluetoothLEPlugin.js` and added my `console.log` and run result

```javascript
  subscribe: function (successCallback, errorCallback, params) {
    if (!initialized) {
      errorCallback({ error: "subscribe", message: "Not initialized." });
      return;
    }

    if (params && params.length > 0 && params[0].address && params[0].service && params[0].characteristic) {
      var deviceId = params[0].address;
      var serviceId = params[0].service;
      var characteristicId = params[0].characteristic;
      var isNotification = params[0].isNotification;

      getCharacteristic(deviceId, serviceId, characteristicId).then(function (characteristic, deviceName) {
        var convertedCharacteristic = convertCharacteristic(characteristic);
        var descriptorValue;


        console.log("isNotification1: " + isNotification)  // -> isNotification1: undefined
        console.log(JSON.stringify(convertedCharacteristic.properties))  // ->  {"indicate":"true"}


        if (isNotification == null) {

          console.log("update isNotification")  // -> not print

          isNotification = convertedCharacteristic.properties.notify === 'true';
        }


        console.log("isNotification2: " + isNotification)  // -> isNotification2: undefined


        if (isNotification || isNotification == null) {
          console.log("set notify")
          descriptorValue = gatt.GattClientCharacteristicConfigurationDescriptorValue.notify;
        } else {
          console.log("set indicate")
          descriptorValue = gatt.GattClientCharacteristicConfigurationDescriptorValue.indicate;
        }
        
        characteristic.writeClientCharacteristicConfigurationDescriptorAsync(descriptorValue).done(function (result) {
                   if (result === gatt.GattCommunicationStatus.success) {
            successCallback({ status: "subscribed", characteristic: characteristicId, name: deviceName, service: serviceId, address: deviceId }, { keepCallback: true });
            characteristic.onvaluechanged = function (result) {
              var value = wsc.CryptographicBuffer.encodeToBase64String(result.characteristicValue);
              successCallback({ status: "subscribedResult", value: value, characteristic: characteristicId, name: deviceName, service: serviceId, address: deviceId }, { keepCallback: true });
            };
          } else {
            errorCallback({ error: "subscribe", message: "Device unreachable." });
          }
        }, function (error) {

          console.log( JSON.stringify(error))
         // -> {"asyncOpType":"Windows.Foundation.IAsyncOperation`1<Windows.Devices.Bluetooth.GenericAttributeProfile.GattCommunicationStatus>","asyncOpCausalityId":101}


          errorCallback({ error: "subscribe", message: error.message });
```