### PR TITLE
Add missing optional address parameter to NotifyParams interface.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+
 # Cordova Bluetooth LE Plugin
 This plugin allows you to interact with Bluetooth LE devices on Android, iOS, and Windows.
 
@@ -2084,6 +2085,7 @@ var params = {
   "service":"1234",
   "characteristic":"ABCD",
   "value":"U3Vic2NyaWJlIEhlbGxvIFdvcmxk" //Subscribe Hello World
+  // "address": "5163F1E0-5341-AF9B-9F67-613E15EC83F7" // only on android
 };
 ```
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -667,7 +667,9 @@ declare namespace BluetoothlePlugin {
         /** Characteristic's UUID */
         characteristic: string,
         /** Base64 encoded string, number or string */
-        value: string
+        value: string,
+        /** Android only: address of the device the notification should be sent to. */
+        address?: string
     }
 
     interface RespondParams {


### PR DESCRIPTION
The (optional) address aprameter was missing from the NotifyParams interface definition and caused problems for Typescript users. In addition, the address parameter was added to the notify example, because the existing mention in the text was easy to read over. (See Issue #652 )