### PR TITLE
Add retrievePeripheralsByAddress method for finding paired devices in iOS by address

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,7 @@ Neither Android nor iOS support Bluetooth on emulators, so you'll need to test o
 * [bluetoothle.requestPermission](#requestpermission) (Android 6+)
 * [bluetoothle.isLocationEnabled](#islocationenabled) (Android 6+)
 * [bluetoothle.requestLocation](#requestlocation) (Android 6+)
+* [bluetoothle.retrievePeripheralsByAddress](#retrievePeripheralsByAddress) (iOS)
 * [bluetoothle.initializePeripheral](#initializeperipheral)
 * [bluetoothle.addService](#addservice)
 * [bluetoothle.removeService](#removeservice)

--- a/readme.md
+++ b/readme.md
@@ -292,6 +292,7 @@ Whenever the error callback is executed, the return object will contain the erro
 * isDisconnected - Device is disconnected (Don't call disconnect)
 * isBonded - Operation is unsupported. (Is the device Android?)
 * setPin - Operation is unsupported. (Is the device Android?)
+* retrievePeripheralsByAddress - Operation is unsupported (Is the device iOS?)
 
 For example:
 ```javascript

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@ This plugin allows you to interact with Bluetooth LE devices on Android, iOS, an
   - [isLocationEnabled](#islocationenabled)
   - [requestLocation](#requestlocation)
   - [setPin](#setPin)
+  - [retrievePeripheralsByAddress](#retrievePeripheralsByAddress)
 - [Peripheral Life Cycle](#peripheral-life-cycle)
   - [Initilization](#initilization)
   - [Notifications](#notifications)
@@ -1745,6 +1746,38 @@ bluetoothle.requestLocation(requestLocationSuccess, requestLocationError);
 {
   "requestLocation": true
 }
+```
+
+
+
+### retrievePeripheralsByAddress ###
+Retrieve paired Bluetooth LE devices based on their address. Wraps the iOS method [CBCentralManager.retrievePeripheralsWithIdentifiers](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1519127-retrieveperipheralswithidentifie?language=objc). iOS support only. Will return an error if used on Android.
+
+```javascript
+bluetoothle.retrievePeripheralsByAddress(success, error, params);
+```
+
+##### Params #####
+* addresses = An arrays of addresses/identifiers to lookup devices by. If no addresses are specified, no devices will be returned
+
+```javascript
+{
+  "addresses": ["ECC037FD-72AE-AFC5-9213-CA785B3B5C63"]
+}
+```
+
+##### Success #####
+Returns an array of device objects:
+* name = the device's display name
+* address = the device's address / identifier for connecting to the object
+
+```javascript
+[
+  {
+    "name": "Polar H7 3B321015",
+    "address": "ECC037FD-72AE-AFC5-9213-CA785B3B5C63"
+  }
+]
 ```
 
 

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -213,6 +213,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
   private final String errorDescriptor = "descriptor";
   private final String errorRequestConnectionPriority = "requestConnectPriority";
   private final String errorMtu = "mtu";
+  private final String errorRetrievePeripheralsByAddress = "retrievePeripheralsByAddress";
 
   //Error Messages
   //Initialization
@@ -424,6 +425,11 @@ public class BluetoothLePlugin extends CordovaPlugin {
       notifyAction(args, callbackContext);
     } else if ("setPin".equals(action)) {
       setPinAction(args, callbackContext);
+    } else if ("retrievePeripheralsByAddress".equals(action)) {
+      JSONObject returnObj = new JSONObject();
+      addProperty(returnObj, keyError, errorRetrievePeripheralsByAddress);
+      addProperty(returnObj, keyMessage, logOperationUnsupported);
+      callbackContext.error(returnObj);
     } else {
       return false;
     }

--- a/src/ios/BluetoothLePlugin.h
+++ b/src/ios/BluetoothLePlugin.h
@@ -62,6 +62,7 @@
 - (void)requestPermission:(CDVInvokedUrlCommand *)command;
 - (void)isLocationEnabled:(CDVInvokedUrlCommand *)command;
 - (void)requestLocation:(CDVInvokedUrlCommand *)command;
+- (void)retrievePeripheralsByAddress:(CDVInvokedUrlCommand *)command;
 
 - (void)initializePeripheral:(CDVInvokedUrlCommand *)command;
 - (void)addService:(CDVInvokedUrlCommand *)command;

--- a/src/ios/BluetoothLePlugin.m
+++ b/src/ios/BluetoothLePlugin.m
@@ -8,6 +8,7 @@ NSString *const keyStatusReceiver = @"statusReceiver";
 NSString *const keyMessage = @"message";
 NSString *const keyName = @"name";
 NSString *const keyAddress = @"address";
+NSString *const keyAddresses = @"addresses";
 NSString *const keyProperties = @"properties";
 NSString *const keyRssi = @"rssi";
 NSString *const keyAdvertisement = @"advertisement";
@@ -825,6 +826,43 @@ NSString *const operationWrite = @"write";
 
   //Get connected connections with specified services
   NSArray* peripherals = [centralManager retrieveConnectedPeripheralsWithServices:serviceUuids];
+
+  //Array to store returned peripherals
+  NSMutableArray* peripheralsOut = [[NSMutableArray alloc] init];
+
+  //Create an object from each peripheral containing connection ID and name, and add to array
+  for (CBPeripheral* peripheral in peripherals) {
+    NSMutableDictionary* peripheralOut = [NSMutableDictionary dictionary];
+    [self addDevice:peripheral :peripheralOut];
+    [peripheralsOut addObject:peripheralOut];
+  }
+
+  //Return the array
+  CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:peripheralsOut];
+  [pluginResult setKeepCallbackAsBool:false];
+  [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (void)retrievePeripheralsByAddress:(CDVInvokedUrlCommand *)command {
+  //Ensure Bluetooth is enabled
+  if ([self isNotInitialized:command]) {
+    return;
+  }
+
+  //Get an array of addresses to filter by
+  NSDictionary *obj = [self getArgsObject:command.arguments];
+  NSMutableArray* addresses = nil;
+  if (obj != nil) {
+    addresses = [self getAddresses:obj forType:keyAddresses];
+  }
+
+  //retrievePeripheralsWithIdentifiers doesn't like nil UUID array
+  if (addresses == nil) {
+    addresses = [NSMutableArray array];
+  }
+
+  //Get paired peripherals with specified addresses/identifiers
+  NSArray* peripherals = [centralManager retrievePeripheralsWithIdentifiers:addresses];
 
   //Array to store returned peripherals
   NSMutableArray* peripheralsOut = [[NSMutableArray alloc] init];
@@ -3448,6 +3486,38 @@ NSString *const operationWrite = @"write";
   }
 
   return [[NSUUID UUID] initWithUUIDString:addressString];
+}
+
+-(NSMutableArray*) getAddresses:(NSDictionary *) dictionary forType:(NSString*) type {
+  NSMutableArray* addresses = [[NSMutableArray alloc] init];
+
+  NSArray* addressStrings = [dictionary valueForKey:type];
+
+  if (addressStrings == nil) {
+    return nil;
+  }
+
+  if (![addressStrings isKindOfClass:[NSArray class]]) {
+    return nil;
+  }
+
+  for (NSString* addressString in addressStrings) {
+    if (![addressString isKindOfClass:[NSString class]]) {
+      continue;
+    }
+
+    NSUUID* address = [[NSUUID UUID] initWithUUIDString:addressString];
+
+    if (address != nil) {
+      [addresses addObject:address];
+    }
+  }
+
+  if (addresses.count == 0) {
+    return nil;
+  }
+
+  return addresses;
 }
 
 -(NSNumber*) getRequest:(NSDictionary *)obj {

--- a/src/osx/BluetoothLePlugin.h
+++ b/src/osx/BluetoothLePlugin.h
@@ -54,6 +54,7 @@
 - (void)requestPermission:(CDVInvokedUrlCommand *)command;
 - (void)isLocationEnabled:(CDVInvokedUrlCommand *)command;
 - (void)requestLocation:(CDVInvokedUrlCommand *)command;
+- (void)retrievePeripheralsByAddress:(CDVInvokedUrlCommand *)command;
 
 - (void)initializePeripheral:(CDVInvokedUrlCommand *)command;
 - (void)addService:(CDVInvokedUrlCommand *)command;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -435,6 +435,19 @@ declare namespace BluetoothlePlugin {
             requestLocationError: (error: Error) => void): void;
 
         /**
+         * Retrieve paired Bluetooth LE devices based on their address. Wraps the iOS method CBCentralManager.retrievePeripheralsWithIdentifiers.
+         * iOS support only. Will return an error if used on Android.
+         * @param success The success callback that is passed an array of device objects
+         * @param error   The callback that will be triggered when the operation fails
+         * @param params  An array of service IDs to filter the retrieval by. If no service IDs are specified, no devices will be returned.
+         *
+         */
+        retrievePeripheralsByAddress(
+            success: (devices: DeviceInfo[]) => void,
+            error: (error: Error) => void,
+            params?: { addresses?: string[] }): void;
+
+        /**
          * Initialize Bluetooth on the device. Must be called before anything else.
          * Callback will continuously be used whenever Bluetooth is enabled or disabled.
          * @param success   The success callback that is passed with InitializeResult object

--- a/www/bluetoothle.js
+++ b/www/bluetoothle.js
@@ -114,6 +114,9 @@ var bluetoothle = {
   requestLocation: function(successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, bluetoothleName, "requestLocation", []);
   },
+  retrievePeripheralsByAddress: function(successCallback, errorCallback, params) {
+    cordova.exec(successCallback, errorCallback, bluetoothleName, "retrievePeripheralsByAddress", [params])
+  },
   initializePeripheral: function(successCallback, errorCallback, params) {
     cordova.exec(successCallback, errorCallback, bluetoothleName, "initializePeripheral", [params]);
   },


### PR DESCRIPTION
In iOS 14, the retrieveConnected method does not appear to support returning all previously paired Bluetooth LE devices, like it does in Android. In iOS 14, it appears to only return information about devices that have a currently active connection. As a result, the plugin does not appear to have any support in iOS for retrieving information about paired BLE devices that do not have an active connection.

To combat this issue, I've added a new method, retrievePeripheralsByAddress. In iOS, this method wraps [CBCentralManager.retrievePeripheralsWithIdentifiers](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/1519127-retrieveperipheralswithidentifie?language=objc). The retrievePeripheralsByAddress method allows plugin users to determine if a known device is already paired, based on its iOS Bluetooth identifier/address.

In Android, the retrievePeripheralsByAddress method will always return an "operation not supported" error.