### PR TITLE
make types into module

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace BluetoothlePlugin {
+export namespace BluetoothlePlugin {
     interface Bluetoothle {
         /**
          * Initialize Bluetooth on the device


### PR DESCRIPTION
This will allow for proper importing of the namespace in typescript.

When working with this plugin in an Angular 2+ (10) project, the namespace was not available as expected without an import statement, but just importing 'cordova-plugin-bluetoothle' caused an error because the types file is not a module. I made this small change and was able to import the namespace as usual `import { BluetoothlePlugin } from 'cordova-plugin-bluetoothle';`.