### PR TITLE
Fix out-of-order notifications on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,7 @@
     </config-file>
     <source-file src="src/android/BluetoothLePlugin.java" target-dir="src/com/randdusing/bluetoothle" />
     <source-file src="src/android/Operation.java" target-dir="src/com/randdusing/bluetoothle" />
+    <source-file src="src/android/SequentialCallbackContext.java" target-dir="src/com/randdusing/bluetoothle" />
     <config-file target="AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.BLUETOOTH"/>
       <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>

--- a/src/android/SequentialCallbackContext.java
+++ b/src/android/SequentialCallbackContext.java
@@ -1,0 +1,48 @@
+// Inspiration taken from cordova-plugin-ble-central
+
+package com.randdusing.bluetoothle;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.PluginResult;
+import java.util.ArrayList;
+import java.util.List;
+import org.json.JSONObject;
+
+public class SequentialCallbackContext {
+    private int sequence;
+    private CallbackContext context;
+
+    public SequentialCallbackContext(CallbackContext context) {
+        this.context = context;
+        this.sequence = 0;
+    }
+
+    private int getNextSequenceNumber() {
+        synchronized(this) {
+            return this.sequence++; 
+        }
+    }
+
+    public CallbackContext getContext() {
+      return this.context;
+    }
+
+    public PluginResult createSequentialResult(JSONObject returnObj) {
+        List<PluginResult> resultList = new ArrayList<PluginResult>(2);
+
+        PluginResult dataResult = new PluginResult(PluginResult.Status.OK, returnObj);
+        PluginResult sequenceResult = new PluginResult(PluginResult.Status.OK, this.getNextSequenceNumber()); 
+
+        resultList.add(dataResult);
+        resultList.add(sequenceResult);
+        
+        return new PluginResult(PluginResult.Status.OK, resultList);
+    }
+
+    public void sendSequentialResult(JSONObject returnObj) {
+        PluginResult result = this.createSequentialResult(returnObj);
+        result.setKeepCallback(true);
+
+        this.context.sendPluginResult(result);
+    }
+}


### PR DESCRIPTION
This pull request ensures the order of ble notifications delivered to subscribers matches the order messages were received over-the-air.

This PR is based off the PR made for cordova-plugin-ble-central (https://github.com/don/cordova-plugin-ble-central/pull/656) and the implementation suggested by Tim Burke (https://github.com/randdusing/cordova-plugin-bluetoothle/issues/419#issuecomment-452058869)

Closes #419 