### PR TITLE
fix: reset writeQIsRunning flag when peripheral disconnects

### DIFF
--- a/src/ios/BluetoothLePlugin.m
+++ b/src/ios/BluetoothLePlugin.m
@@ -2256,6 +2256,9 @@ NSString *const operationWrite = @"write";
   if (callback == nil) {
     return;
   }
+  
+  //Reset writeQIsRunning flag since we have no way of knowing if one was interupted
+  writeQIsRunning = false;
 
   //Return disconnected connection information
   NSMutableDictionary* returnObj = [NSMutableDictionary dictionary];


### PR DESCRIPTION
From [Apple Developer docs](https://developer.apple.com/documentation/corebluetooth/cbperipheral/1518747-writevalue?language=objc):
>On the other hand, if you specify the write type as CBCharacteristicWriteWithoutResponse, Core Bluetooth attempts to write the value but doesn’t guarantee success. **If the write doesn’t succeed in this case, you aren’t notified and you don’t receive an error indicating the cause of the failure**.

Therefore i just set the flag to `false` on `didDisconnectPeripheral`. If there's a better way to deal with this please contribute it.

resolves #690