### PR TITLE
Add support for advertising service data on Android

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -747,10 +747,14 @@ public class BluetoothLePlugin extends CordovaPlugin {
       dataBuilder.addManufacturerData(manufacturerId, manufacturerSpecificData);
     }
 
-    //dataBuilder.addServiceData();
     UUID uuid = getUUID(obj.optString("service", null));
     if (uuid != null) {
-      dataBuilder.addServiceUuid(new ParcelUuid(uuid));
+      byte[] serviceData = getPropertyBytes(obj, "serviceData");
+      if (serviceData != null) {
+        dataBuilder.addServiceData(new ParcelUuid(uuid), serviceData);
+      } else {
+        dataBuilder.addServiceUuid(new ParcelUuid(uuid));
+      }
     }
 
     dataBuilder.setIncludeDeviceName(obj.optBoolean("includeDeviceName", true));


### PR DESCRIPTION
Support service data advertising on Android devices. If serviceData property is defined, use addServiceData() instead of addServiceUuid(). There may be a bug on pre-8.1 Android though, where 128-bit UUIDs always get truncated to 16-bit: [https://stackoverflow.com/questions/56581387/android-ble-advertising-uuid-length-differs-on-different-sdk-level](url).