### PR TITLE
Android: Per-peripheral operation queueing

### DIFF
--- a/src/android/Operation.java
+++ b/src/android/Operation.java
@@ -8,7 +8,6 @@ public class Operation {
   public String type;
   public JSONArray args;
   public CallbackContext callbackContext;
-  public BluetoothDevice device;
 
   public Operation(String type, JSONArray args, CallbackContext callbackContext) {
     this.type = type;


### PR DESCRIPTION
Read, write, and other operations are currently being queued globally. On Android, operations only need to be queued per BluetoothGatt instance (per connection). This commit enables Android to handle the scheduling of operations between peripherals.