### PR TITLE
[Feature] Added support for multiple & same uuid's

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1142,7 +1142,9 @@ bluetoothle.read(readSuccess, readError, params);
 ##### Params #####
 * address = The address/identifier provided by the scan's return object
 * service = The service's UUID
+* serviceIndex = When dealing with multiple services with the same UUID, this index will determine which service will be used (OPTIONAL)
 * characteristic = The characteristic's UUID
+* characteristicIndex = When dealing with multiple characteristics with the same UUID, this index will determine which chracteristic will be used (OPTIONAL)
 
 ```javascript
 {
@@ -1180,7 +1182,9 @@ bluetoothle.subscribe(subscribeSuccess, subscribeError, params);
 ##### Params #####
 * address = The address/identifier provided by the scan's return object
 * service = The service's UUID
+* serviceIndex = When dealing with multiple services with the same UUID, this index will determine which service will be used (OPTIONAL)
 * characteristic = The characteristic's UUID
+* characteristicIndex = When dealing with multiple characteristics with the same UUID, this index will determine which chracteristic will be used (OPTIONAL)
 
 ```javascript
 {
@@ -1201,8 +1205,10 @@ bluetoothle.subscribe(subscribeSuccess, subscribeError, params);
 {
   "status": "subscribed",
   "characteristic": "2a37",
+  "characteristicIndex": 0,
   "name": "Polar H7 3B321015",
   "service": "180d",
+  "serviceIndex": 0,
   "address": "ECC037FD-72AE-AFC5-9213-CA785B3B5C63"
 }
 
@@ -1210,8 +1216,10 @@ bluetoothle.subscribe(subscribeSuccess, subscribeError, params);
   "status": "subscribedResult",
   "value": "U3Vic2NyaWJlIEhlbGxvIFdvcmxk", //Subscribe Hello World
   "characteristic": "2a37",
+  "characteristicIndex": 0,
   "name": "Polar H7 3B321015",
   "service": "180d",
+  "serviceIndex": 0,
   "address": "ECC037FD-72AE-AFC5-9213-CA785B3B5C63"
 }
 ```
@@ -1228,7 +1236,9 @@ bluetoothle.unsubscribe(unsubscribeSuccess, unsubscribeError, params);
 ##### Params #####
 * address = The address/identifier provided by the scan's return object
 * service = The service's UUID
+* serviceIndex = When dealing with multiple services with the same UUID, this index will determine which service will be used (OPTIONAL)
 * characteristic = The characteristic's UUID
+* characteristicIndex = When dealing with multiple characteristics with the same UUID, this index will determine which chracteristic will be used (OPTIONAL)
 
 ```javascript
 {
@@ -1265,7 +1275,9 @@ bluetoothle.write(writeSuccess, writeError, params);
 ##### Params #####
 * address = The address/identifier provided by the scan's return object
 * service = The service's UUID
+* serviceIndex = When dealing with multiple services with the same UUID, this index will determine which service will be used (OPTIONAL)
 * characteristic = The characteristic's UUID
+* characteristicIndex = When dealing with multiple characteristics with the same UUID, this index will determine which chracteristic will be used (OPTIONAL)
 * value = Base64 encoded string
 * type = Set to "noResponse" to enable write without response, all other values will write normally.
 
@@ -1312,7 +1324,9 @@ bluetoothle.writeQ(writeSuccess, writeError, params);
 ##### Params #####
 * address = The address/identifier provided by the scan's return object
 * service = The service's UUID
+* serviceIndex = When dealing with multiple services with the same UUID, this index will determine which service will be used (OPTIONAL)
 * characteristic = The characteristic's UUID
+* characteristicIndex = When dealing with multiple characteristics with the same UUID, this index will determine which chracteristic will be used (OPTIONAL)
 * value = Base64 encoded string
 * type = Set to "noResponse" to enable write without response, all other values will write normally.
 * chunkSize = Define the size of packets. This should be according to MTU value

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -625,7 +625,9 @@ declare namespace BluetoothlePlugin {
         /** The address/identifier provided by the scan's return object */
         address: string,
         /** The service's ID */
-        service: string
+        service: string,
+        /** When dealing with multiple services with the same UUID, this index will determine which service will be used */
+        serviceIndex?: number
     }
 
     interface InitPeripheralParams {
@@ -714,8 +716,10 @@ declare namespace BluetoothlePlugin {
     }
 
     interface DescriptorParams extends Params {
-        /** The characteristic's ID */
-        characteristic: string
+      /** The characteristic's ID */
+      characteristic: string;
+      /** When dealing with multiple characteristics with the same UUID, this index will determine which chracteristic will be used */
+      characteristicIndex?: number;
     }
 
     interface OperationDescriptorParams  extends DescriptorParams {
@@ -917,8 +921,12 @@ declare namespace BluetoothlePlugin {
     interface OperationResult extends DeviceInfo {
         /** Characteristic UUID */
         characteristic: string,
+        /** When dealing with multiple characteristics with the same UUID, this index will determine which characteristic it is */
+        characteristicIndex: number,
         /** Service's UUID */
         service: string,
+        /** When dealing with multiple services with the same UUID, this index will determine which service it is */
+        serviceIndex: number,
         /** Base64 encoded string of bytes */
         value: string
     }


### PR DESCRIPTION
The same PR as #697 , but now with a clean git history. The feature is fully tested on iOS and Android via this package: [npmjs Bastiaanver](https://www.npmjs.com/package/@bastiaanver/cordova-plugin-bluetoothle)

**Old PR description**
Currently, I am working on a Bluetooth project which has multiple services with the same UUID. Sadly, there aren't many libraries which supports this kind of functionality, so therefore I open this PR.

A example:
- Lightbulb 1 (service UUID: 00403148-59CE-40EE-90AA-AB6A874119C7)
- Lightbulb 2 (service UUID: 00403148-59CE-40EE-90AA-AB6A874119C7)
- Lightbulb 3 (service UUID: 00403148-59CE-40EE-90AA-AB6A874119C7)
- Lightbulb 4 (service UUID: 00403148-59CE-40EE-90AA-AB6A874119C7)
- Sun blind 1 (service UUID: 00803148-59CE-40EE-90AA-AB6A874119C7)
- Sun blind 2 (service UUID: 00803148-59CE-40EE-90AA-AB6A874119C7)

Let's say, I want the third lightbulb. I can now use this project as follows:
```js
bluetoothle.read(
    console.log,
    console.error,
    {
        address: "ECC037FD-72AE-AFC5-9213-CA785B3B5C63",
        service: "00403148-59CE-40EE-90AA-AB6A874119C7",
        serviceIndex: 2, // Zero-based index
        characteristic: "00423148-59CE-40EE-90AA-AB6A874119C7",
    }
);
```

This method will work on read, write and (un)subscribe actions, using the same json keys