### PR TITLE
added missing prop to RespondParams for typescript typings.

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -708,6 +708,8 @@ declare namespace BluetoothlePlugin {
         value: string,
         /** not documented */
         offset?: number
+        /** Android only: address of the device the response should be sent to. */
+        address?: string
     }
 
     interface CharacteristicParams extends Params {


### PR DESCRIPTION
updated typings for index.d.ts to include address property in RespondParams, This is required for Android respond() execution.