### PR TITLE
- queueAdd method add exception handling when queue in connection is …

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -3304,9 +3304,24 @@ public class BluetoothLePlugin extends CordovaPlugin {
 
     HashMap<Object, Object> connection = connections.get(address);
 
+    // When Connection is Valid
     if (connection != null) {
+      // Get operation Queue from connection
       LinkedList<Operation> queue = (LinkedList<Operation>) connection.get(keyQueue);
+
+      // When queue is not valid
+      if(queue == null) {
+        // Create dummy queue
+        queue = new LinkedList<>();
+
+        // Add dummy queue to connection
+        connection.put(keyQueue, queue);
+      }
+
+      // Add operation to queue
       queue.add(operation);
+
+      // Start Queue
       queueStart(connection);
     }
   }


### PR DESCRIPTION
add exception handling to queueAdd method .
when queue in connection is null avoid above error.

- java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.util.LinkedList.add(java.lang.Object)' on a null object reference