### PR TITLE
Add whether Bluetooth scan is in traditional mode(ScanSettings.Builder.setLegacy())

### DIFF
--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -105,6 +105,7 @@ public class BluetoothLePlugin extends CordovaPlugin {
   private final String keyMatchMode = "matchMode";
   private final String keyMatchNum = "matchNum";
   private final String keyCallbackType = "callbackType";
+  private final String keyIsLegacy = "isLegacy";
   private final String keyAdvertisement = "advertisement";
   private final String keyUuid = "uuid";
   private final String keyService = "service";
@@ -1287,6 +1288,12 @@ public class BluetoothLePlugin extends CordovaPlugin {
         } catch (java.lang.IllegalArgumentException e) {
         }
       }
+
+      
+		  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+			  boolean isLegacy = obj.optBoolean(keyIsLegacy, true);
+			  scanSettings.setLegacy(isLegacy);
+		  }
 
       //Start the scan with or without service UUIDs
       bluetoothAdapter.getBluetoothLeScanner().startScan(scanFilter, scanSettings.build(), scanCallback);

--- a/src/android/BluetoothLePlugin.java
+++ b/src/android/BluetoothLePlugin.java
@@ -1288,13 +1288,13 @@ public class BluetoothLePlugin extends CordovaPlugin {
         } catch (java.lang.IllegalArgumentException e) {
         }
       }
-
-      
-		  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-			  boolean isLegacy = obj.optBoolean(keyIsLegacy, true);
-			  scanSettings.setLegacy(isLegacy);
-		  }
-
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+	boolean isLegacy = obj.optBoolean(keyIsLegacy, false);
+	try {
+	  scanSettings.setLegacy(isLegacy);
+	} catch (IllegalArgumentException e) {
+	}
+      }
       //Start the scan with or without service UUIDs
       bluetoothAdapter.getBluetoothLeScanner().startScan(scanFilter, scanSettings.build(), scanCallback);
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -703,6 +703,11 @@ declare namespace BluetoothlePlugin {
         callbackType?: BluetoothCallbackType,
         /** True/false to show only connectable devices, rather than all devices ever seen, defaults to false (Windows)*/
         isConnectable?: boolean
+        /** Used to set whether scanning is in "legacy" mode. In Bluetooth 5, a new scanning mode is introduced to support more 
+            functions and features, such as extended advertising, long data packets, etc. The "legacy" mode only supports 
+            traditional advertising data types and does not support Bluetooth 5's extended advertising.
+        */
+        isLegacy?:boolean
     }
 
     interface ConnectionParams{


### PR DESCRIPTION
![PixPin_2024-03-27_13-19-00](https://github.com/randdusing/cordova-plugin-bluetoothle/assets/80421914/45766c41-807b-457e-ac04-22da92dc3199)
While using the application recently, I encountered an issue where the device couldn't be scanned. After investigating, I found that the device's advertising type is Bluetooth 5 Advertising Extension. Upon consulting the Android documentation, I discovered that the ScanSettings.Builder.setLegacy() method was introduced in Android 26 API.

[Link to Android Documentation](https://developer.android.com/reference/android/bluetooth/le/ScanSettings.Builder#setLegacy(boolean))

setLegacy(false) is a method in ScanSettings.Builder that determines whether the scan operates in "legacy" mode. With Bluetooth 5, a new scanning mode was introduced to support additional features like extended advertising and long data packets. Conversely, "legacy" mode only supports traditional advertising data types and does not accommodate Bluetooth 5's extended advertising.

Hence, when you use setLegacy(false), you're instructing the system not to employ "legacy" mode, but rather to use the new mode, enabling scanning for Bluetooth 5's extended advertisements and other new features.

Based on this understanding, I propose adding a parameter isLegacy() to confirm whether to activate scanning in legacy mode. Below is the code I added:

```
if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
    boolean isLegacy = obj.optBoolean(keyIsLegacy, true);
    scanSettings.setLegacy(isLegacy);
}
```
This change allows for flexible configuration of the scan mode, ensuring compatibility and functionality as required.
